### PR TITLE
Master invisible light improvement

### DIFF
--- a/java/com/tartaric_acid/baka943/ConfigLoader.java
+++ b/java/com/tartaric_acid/baka943/ConfigLoader.java
@@ -1,0 +1,39 @@
+package com.tartaric_acid.baka943;
+
+import org.apache.logging.log4j.Logger;
+
+import net.minecraftforge.common.config.Configuration;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+
+public class ConfigLoader {
+
+    private static Configuration config;
+    private static Logger logger;
+    
+    public static boolean useTileEntityToTickInvisibleLight;
+    public static boolean showNonTEInvisibleLight;
+    
+    public ConfigLoader(FMLPreInitializationEvent event)
+    {
+        logger = event.getModLog();
+        config = new Configuration(event.getSuggestedConfigurationFile());
+        config.load();
+        load();
+    }
+
+    public static void load()
+    {
+        logger.info("Started loading config.");
+        String useTEToTickInvisbleLightDes = "Whether using a TileEntity to help tick the invisible light. Set to true will enhance the performance of Invisible Light, but might cause a potential lag.";
+        String showNonTEInvisbleLightDes = "Set to true will show the invisible light which doesn't have a TileEntity when the useTileEntityToTickInvisibleLight mode is on.";
+        useTileEntityToTickInvisibleLight = config.get(Configuration.CATEGORY_GENERAL, "useTileEntityToTickInvisibleLight", true, useTEToTickInvisbleLightDes).getBoolean();
+        showNonTEInvisibleLight = config.get(Configuration.CATEGORY_GENERAL, "showAllInvisibleLight", true, showNonTEInvisbleLightDes).getBoolean();
+        config.save();
+        logger.info("Finished loading config.");
+    }
+
+    public static Logger logger()
+    {
+        return logger;
+    }
+}

--- a/java/com/tartaric_acid/baka943/CraftingLoader.java
+++ b/java/com/tartaric_acid/baka943/CraftingLoader.java
@@ -20,8 +20,8 @@ import vazkii.botania.common.lib.LibOreDict;
 
 public class CraftingLoader
 {
-	public static List<RecipeManaInfusion> woodRecipes;
-	
+    public static List<RecipeManaInfusion> woodRecipes;
+    
     public CraftingLoader()
     {
         registerRecipe();
@@ -29,36 +29,36 @@ public class CraftingLoader
 
     private static void registerRecipe()
     {      
-    	
-    	//Recipe For Guide Block
-    	GameRegistry.addShapedRecipe(new ItemStack(BlockLoader.blockGuide), new Object[]
-    	        {
-    	                "###", "#*#", "###",
-    	                '#', Items.IRON_INGOT,
-    	                '*', Blocks.WOOL
-    	        });
-    	
-    	//Recipe For Invisible Light
-    	GameRegistry.addShapedRecipe(new ItemStack(BlockLoader.invisibleLight), new Object[]
-    	        {
-    	                "##",
-    	                '#', Blocks.TORCH
-    	        });
-    	GameRegistry.addShapelessRecipe(new ItemStack(Blocks.TORCH, 2), BlockLoader.invisibleLight);
-    	
-    	
-    	//Recipe For Infinite Hoe Inactive    	
-    	GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemLoader.infiniteHoeInactive), new Object[]
-    	        {
-    	                "## ", " * ", " * ",
-    	                '#', "ingotTerrasteel",
-    	                '*', Items.STICK
-    	        }));   	
-    	    	
-    	
-    	woodRecipes = new ArrayList<RecipeManaInfusion>();
-    	woodRecipes.add(BotaniaAPI.registerManaAlchemyRecipe(new ItemStack(BlockLoader.invisibleLight, 1), new ItemStack(Blocks.TORCH, 1), 300));
-    	woodRecipes.add(BotaniaAPI.registerManaAlchemyRecipe(new ItemStack(ItemLoader.infiniteHoeActive, 1), new ItemStack(ItemLoader.infiniteHoeInactive, 1), 1000000));
+        
+        //Recipe For Guide Block
+        GameRegistry.addShapedRecipe(new ItemStack(BlockLoader.blockGuide), new Object[]
+                {
+                        "###", "#*#", "###",
+                        '#', Items.IRON_INGOT,
+                        '*', Blocks.WOOL
+                });
+        
+        //Recipe For Invisible Light
+        GameRegistry.addShapedRecipe(new ItemStack(BlockLoader.invisibleLight), new Object[]
+                {
+                        "##",
+                        '#', Blocks.TORCH
+                });
+        GameRegistry.addShapelessRecipe(new ItemStack(Blocks.TORCH, 2), BlockLoader.invisibleLight);
+        
+        
+        //Recipe For Infinite Hoe Inactive        
+        GameRegistry.addRecipe(new ShapedOreRecipe(new ItemStack(ItemLoader.infiniteHoeInactive), new Object[]
+                {
+                        "## ", " * ", " * ",
+                        '#', "ingotTerrasteel",
+                        '*', Items.STICK
+                }));       
+                
+        
+        woodRecipes = new ArrayList<RecipeManaInfusion>();
+        woodRecipes.add(BotaniaAPI.registerManaAlchemyRecipe(new ItemStack(BlockLoader.invisibleLight, 1), new ItemStack(Blocks.TORCH, 1), 300));
+        woodRecipes.add(BotaniaAPI.registerManaAlchemyRecipe(new ItemStack(ItemLoader.infiniteHoeActive, 1), new ItemStack(ItemLoader.infiniteHoeInactive, 1), 1000000));
     }
 }
-        
+

--- a/java/com/tartaric_acid/baka943/block/BlockGuide.java
+++ b/java/com/tartaric_acid/baka943/block/BlockGuide.java
@@ -7,14 +7,14 @@ import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
 
 public class BlockGuide extends Block {
-	public BlockGuide()
-	{
-		super(Material.IRON);
+    public BlockGuide()
+    {
+        super(Material.IRON);
         this.setUnlocalizedName("blockGuide");
         this.setHardness(2.0F);
         this.setHarvestLevel("pickaxe", 1);
         this.setSoundType(SoundType.METAL);
         this.setResistance(20);
         this.setCreativeTab(CreativeTabsLoader.tabBaka943);
-	}
+    }
 }

--- a/java/com/tartaric_acid/baka943/block/BlockLoader.java
+++ b/java/com/tartaric_acid/baka943/block/BlockLoader.java
@@ -11,9 +11,9 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class BlockLoader {
-	
-	public static Block blockGuide = new BlockGuide();	
-	public static Block invisibleLight = new InvisibleLight();
+    
+    public static Block blockGuide = new BlockGuide();    
+    public static Block invisibleLight = new InvisibleLight();
     public BlockLoader(FMLPreInitializationEvent event)
     {
         register(blockGuide, "block_guide");       

--- a/java/com/tartaric_acid/baka943/block/InvisibleLight.java
+++ b/java/com/tartaric_acid/baka943/block/InvisibleLight.java
@@ -32,102 +32,102 @@ import net.minecraftforge.fml.client.FMLClientHandler;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
-public class InvisibleLight extends Block {	
-	
-	private static final PropertyBool VISIBLE = PropertyBool.create("visible");
-	
-	public InvisibleLight() {
-		super(Material.CLOTH);
+public class InvisibleLight extends Block {    
+    
+    private static final PropertyBool VISIBLE = PropertyBool.create("visible");
+    
+    public InvisibleLight() {
+        super(Material.CLOTH);
         this.setUnlocalizedName("invisibleLight");
         this.setHardness(0.1F);
         this.setSoundType(SoundType.CLOTH);
         this.setResistance(20);
         this.setCreativeTab(CreativeTabsLoader.tabBaka943); 
         this.setLightLevel(1.0F);
-	}	
-	
-	@Override
-	public EnumBlockRenderType getRenderType(IBlockState state) {
+    }    
+    
+    @Override
+    public EnumBlockRenderType getRenderType(IBlockState state) {
         return state.getValue(VISIBLE)? EnumBlockRenderType.MODEL: EnumBlockRenderType.INVISIBLE;
-	}
-	
-	@Override
-	public BlockRenderLayer getBlockLayer() {
-		return BlockRenderLayer.CUTOUT;
-	}	
-	
-	@Override
-	public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
-		if (!ConfigLoader.useTileEntityToTickInvisibleLight || ConfigLoader.showNonTEInvisibleLight)
-			updateBlockState(stateIn, worldIn, pos);
-	}		
-	
-	public void updateBlockState(IBlockState stateIn, World worldIn, BlockPos pos) {
-		ItemStack mainhand = FMLClientHandler.instance().getClient().thePlayer.getHeldItemMainhand();
+    }
+    
+    @Override
+    public BlockRenderLayer getBlockLayer() {
+        return BlockRenderLayer.CUTOUT;
+    }    
+    
+    @Override
+    public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
+        if (!ConfigLoader.useTileEntityToTickInvisibleLight || ConfigLoader.showNonTEInvisibleLight)
+            updateBlockState(stateIn, worldIn, pos);
+    }        
+    
+    public void updateBlockState(IBlockState stateIn, World worldIn, BlockPos pos) {
+        ItemStack mainhand = FMLClientHandler.instance().getClient().thePlayer.getHeldItemMainhand();
 
-		if (mainhand != null) {
-	        Item item = mainhand.getItem();
-	        if (((item instanceof ItemBlock))&&(Block.getBlockFromItem(item) == BlockLoader.invisibleLight)) {
-	          worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, true)); 
-	          return;
-	        }
-		}
-				
-		worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, false));
-	}
-	
-	@Override
-	public boolean hasTileEntity(IBlockState state) {
-		return ConfigLoader.useTileEntityToTickInvisibleLight;
-	}
-	
-	@Override
-	public TileEntity createTileEntity(World world, IBlockState state) {
-		return ConfigLoader.useTileEntityToTickInvisibleLight? new TileInvisibleLight(): super.createTileEntity(world, state);
-	}
-	
-	@Nullable
+        if (mainhand != null) {
+            Item item = mainhand.getItem();
+            if (((item instanceof ItemBlock))&&(Block.getBlockFromItem(item) == BlockLoader.invisibleLight)) {
+              worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, true)); 
+              return;
+            }
+        }
+                
+        worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, false));
+    }
+    
+    @Override
+    public boolean hasTileEntity(IBlockState state) {
+        return ConfigLoader.useTileEntityToTickInvisibleLight;
+    }
+    
+    @Override
+    public TileEntity createTileEntity(World world, IBlockState state) {
+        return ConfigLoader.useTileEntityToTickInvisibleLight? new TileInvisibleLight(): super.createTileEntity(world, state);
+    }
+    
+    @Nullable
     public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, World worldIn, BlockPos pos) {
         return NULL_AABB;
     }
-	
-	@Override
-	public boolean canCollideCheck(IBlockState state, boolean hitIfLiquid) {
-		return state.getValue(VISIBLE);
+    
+    @Override
+    public boolean canCollideCheck(IBlockState state, boolean hitIfLiquid) {
+        return state.getValue(VISIBLE);
     }
-	
-	@Override
-	public boolean isFullCube(IBlockState state) {
+    
+    @Override
+    public boolean isFullCube(IBlockState state) {
         return false;
     }
-	
-	@Override
-	public boolean isOpaqueCube(IBlockState state) {
+    
+    @Override
+    public boolean isOpaqueCube(IBlockState state) {
         return false;
     }
-	
-	@Override
-	public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
+    
+    @Override
+    public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
         return true;
     }
-	
-	@Override
-	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced) {
-		int meta = stack.getMetadata();	
-		tooltip.add(I18n.format("baka943.tip.block.invisible_light", meta));
+    
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced) {
+        int meta = stack.getMetadata();    
+        tooltip.add(I18n.format("baka943.tip.block.invisible_light", meta));
     }
-	
-	@Override
-	public IBlockState getStateFromMeta(int meta) {
-		return getDefaultState().withProperty(VISIBLE, meta != 0);
-	}
-	
-	@Override
-	public int getMetaFromState(IBlockState state) {
-		return state.getValue(VISIBLE)? 1: 0;
-	}
-		
+    
+    @Override
+    public IBlockState getStateFromMeta(int meta) {
+        return getDefaultState().withProperty(VISIBLE, meta != 0);
+    }
+    
+    @Override
+    public int getMetaFromState(IBlockState state) {
+        return state.getValue(VISIBLE)? 1: 0;
+    }
+        
     @Override
     protected BlockStateContainer createBlockState() {
         return new BlockStateContainer(this, VISIBLE);

--- a/java/com/tartaric_acid/baka943/block/InvisibleLight.java
+++ b/java/com/tartaric_acid/baka943/block/InvisibleLight.java
@@ -6,17 +6,23 @@ import java.util.Random;
 import javax.annotation.Nullable;
 
 import com.tartaric_acid.baka943.Baka943;
+import com.tartaric_acid.baka943.ConfigLoader;
 import com.tartaric_acid.baka943.CreativeTabsLoader;
+import com.tartaric_acid.baka943.tileentity.TileInvisibleLight;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.resources.I18n;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemBlock;
 import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
 import net.minecraft.util.math.AxisAlignedBB;
 import net.minecraft.util.math.BlockPos;
@@ -28,78 +34,103 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class InvisibleLight extends Block {	
 	
-	private boolean isVisible = false;
+	private static final PropertyBool VISIBLE = PropertyBool.create("visible");
 	
-	public InvisibleLight()
-	{
-		super(Material.GLASS);
+	public InvisibleLight() {
+		super(Material.CLOTH);
         this.setUnlocalizedName("invisibleLight");
         this.setHardness(0.1F);
-        this.setSoundType(SoundType.GLASS);
+        this.setSoundType(SoundType.CLOTH);
         this.setResistance(20);
         this.setCreativeTab(CreativeTabsLoader.tabBaka943); 
         this.setLightLevel(1.0F);
-        this.translucent = true;
-    }
+	}	
 	
-	public EnumBlockRenderType getRenderType(IBlockState state)
-    {
-        return EnumBlockRenderType.INVISIBLE;
-    }
+	@Override
+	public EnumBlockRenderType getRenderType(IBlockState state) {
+        return state.getValue(VISIBLE)? EnumBlockRenderType.MODEL: EnumBlockRenderType.INVISIBLE;
+	}
 	
-	public boolean isOpaqueCube(IBlockState state)
-    {
-        return false;
-    }
+	@Override
+	public BlockRenderLayer getBlockLayer() {
+		return BlockRenderLayer.CUTOUT;
+	}	
 	
-	@SideOnly(Side.CLIENT)
-    public float getAmbientOcclusionLightValue(IBlockState state)
-    {
-        return 1.0F;
-    }
+	@Override
+	public void randomDisplayTick(IBlockState stateIn, World worldIn, BlockPos pos, Random rand) {
+		if (!ConfigLoader.useTileEntityToTickInvisibleLight || ConfigLoader.showNonTEInvisibleLight)
+			updateBlockState(stateIn, worldIn, pos);
+	}		
 	
-	@Nullable
-    public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, World worldIn, BlockPos pos)
-    {
-        return NULL_AABB;
-    }
-	
-	public boolean isFullCube(IBlockState state)
-    {
-        return false;
-    }
-	
-	public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos)
-    {
-        return true;
-    }
-	
-	public boolean canCollideCheck(IBlockState state, boolean hitIfLiquid)
-    {		
+	public void updateBlockState(IBlockState stateIn, World worldIn, BlockPos pos) {
 		ItemStack mainhand = FMLClientHandler.instance().getClient().thePlayer.getHeldItemMainhand();
-		this.isVisible = false;
-		
+
 		if (mainhand != null) {
 	        Item item = mainhand.getItem();
 	        if (((item instanceof ItemBlock))&&(Block.getBlockFromItem(item) == BlockLoader.invisibleLight)) {
-	          this.isVisible = true;
+	          worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, true)); 
+	          return;
 	        }
 		}
-	        
-	    if (this.isVisible) {	            
-	    	return true;
-	    } else {
-	        return false;
-	    }		
+				
+		worldIn.setBlockState(pos, stateIn.withProperty(VISIBLE, false));
+	}
+	
+	@Override
+	public boolean hasTileEntity(IBlockState state) {
+		return ConfigLoader.useTileEntityToTickInvisibleLight;
+	}
+	
+	@Override
+	public TileEntity createTileEntity(World world, IBlockState state) {
+		return ConfigLoader.useTileEntityToTickInvisibleLight? new TileInvisibleLight(): super.createTileEntity(world, state);
+	}
+	
+	@Nullable
+    public AxisAlignedBB getCollisionBoundingBox(IBlockState blockState, World worldIn, BlockPos pos) {
+        return NULL_AABB;
     }
- 
-		
+	
+	@Override
+	public boolean canCollideCheck(IBlockState state, boolean hitIfLiquid) {
+		return state.getValue(VISIBLE);
+    }
+	
+	@Override
+	public boolean isFullCube(IBlockState state) {
+        return false;
+    }
+	
+	@Override
+	public boolean isOpaqueCube(IBlockState state) {
+        return false;
+    }
+	
+	@Override
+	public boolean isReplaceable(IBlockAccess worldIn, BlockPos pos) {
+        return true;
+    }
+	
 	@Override
 	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
-    {
+	public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced) {
 		int meta = stack.getMetadata();	
 		tooltip.add(I18n.format("baka943.tip.block.invisible_light", meta));
     }
+	
+	@Override
+	public IBlockState getStateFromMeta(int meta) {
+		return getDefaultState().withProperty(VISIBLE, meta != 0);
+	}
+	
+	@Override
+	public int getMetaFromState(IBlockState state) {
+		return state.getValue(VISIBLE)? 1: 0;
+	}
 		
+    @Override
+    protected BlockStateContainer createBlockState() {
+        return new BlockStateContainer(this, VISIBLE);
+    }
+
 }

--- a/java/com/tartaric_acid/baka943/client/ItemRenderLoader.java
+++ b/java/com/tartaric_acid/baka943/client/ItemRenderLoader.java
@@ -4,7 +4,7 @@ import com.tartaric_acid.baka943.block.BlockLoader;
 import com.tartaric_acid.baka943.item.ItemLoader;
 
 public class ItemRenderLoader {
-	public ItemRenderLoader()
+    public ItemRenderLoader()
     {
         BlockLoader.registerRenders();
         ItemLoader.registerRenders();

--- a/java/com/tartaric_acid/baka943/common/CommonProxy.java
+++ b/java/com/tartaric_acid/baka943/common/CommonProxy.java
@@ -15,8 +15,8 @@ public class CommonProxy
 {
     public void preInit(FMLPreInitializationEvent event)
     {
-    	new ConfigLoader(event);
-    	new CreativeTabsLoader(event);    	
+        new ConfigLoader(event);
+        new CreativeTabsLoader(event);        
         new BlockLoader(event);
         new ItemLoader(event);
         new TileEntityLoader();
@@ -24,7 +24,7 @@ public class CommonProxy
 
     public void init(FMLInitializationEvent event)
     {
-    	new CraftingLoader();
+        new CraftingLoader();
     }
 
     public void postInit(FMLPostInitializationEvent event)

--- a/java/com/tartaric_acid/baka943/common/CommonProxy.java
+++ b/java/com/tartaric_acid/baka943/common/CommonProxy.java
@@ -1,9 +1,11 @@
 package com.tartaric_acid.baka943.common;
 
+import com.tartaric_acid.baka943.ConfigLoader;
 import com.tartaric_acid.baka943.CraftingLoader;
 import com.tartaric_acid.baka943.CreativeTabsLoader;
 import com.tartaric_acid.baka943.block.BlockLoader;
 import com.tartaric_acid.baka943.item.ItemLoader;
+import com.tartaric_acid.baka943.tileentity.TileEntityLoader;
 
 import net.minecraftforge.fml.common.event.FMLInitializationEvent;
 import net.minecraftforge.fml.common.event.FMLPostInitializationEvent;
@@ -13,9 +15,11 @@ public class CommonProxy
 {
     public void preInit(FMLPreInitializationEvent event)
     {
+    	new ConfigLoader(event);
     	new CreativeTabsLoader(event);    	
         new BlockLoader(event);
         new ItemLoader(event);
+        new TileEntityLoader();
     }
 
     public void init(FMLInitializationEvent event)

--- a/java/com/tartaric_acid/baka943/item/InfiniteHoeActive.java
+++ b/java/com/tartaric_acid/baka943/item/InfiniteHoeActive.java
@@ -14,8 +14,8 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class InfiniteHoeActive extends ItemHoe
 {
-	public static final ToolMaterial InfiniteToolMaterial = EnumHelper.addToolMaterial("INFINITE", 2, 0, 3.0F, 2.0F, 14);
-	
+    public static final ToolMaterial InfiniteToolMaterial = EnumHelper.addToolMaterial("INFINITE", 2, 0, 3.0F, 2.0F, 14);
+    
     public InfiniteHoeActive()
     {
         super(InfiniteToolMaterial);
@@ -24,10 +24,10 @@ public class InfiniteHoeActive extends ItemHoe
     }
     
     @Override
-	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
     {
-		int meta = stack.getMetadata();	
-		tooltip.add(I18n.format("baka943.tip.item.infinite_hoe_active", meta));
+        int meta = stack.getMetadata();    
+        tooltip.add(I18n.format("baka943.tip.item.infinite_hoe_active", meta));
     }  
 }

--- a/java/com/tartaric_acid/baka943/item/InfiniteHoeInactive.java
+++ b/java/com/tartaric_acid/baka943/item/InfiniteHoeInactive.java
@@ -22,10 +22,10 @@ public class InfiniteHoeInactive extends Item
     }
     
     @Override
-	@SideOnly(Side.CLIENT)
-	public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
+    @SideOnly(Side.CLIENT)
+    public void addInformation(ItemStack stack, EntityPlayer player, List<String> tooltip, boolean advanced)
     {
-		int meta = stack.getMetadata();	
-		tooltip.add(I18n.format("baka943.tip.item.infinite_hoe_inactive", meta));
+        int meta = stack.getMetadata();    
+        tooltip.add(I18n.format("baka943.tip.item.infinite_hoe_inactive", meta));
     }
 }

--- a/java/com/tartaric_acid/baka943/tileentity/TileEntityLoader.java
+++ b/java/com/tartaric_acid/baka943/tileentity/TileEntityLoader.java
@@ -1,0 +1,23 @@
+package com.tartaric_acid.baka943.tileentity;
+
+import com.tartaric_acid.baka943.Baka943;
+import com.tartaric_acid.baka943.ConfigLoader;
+
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.fml.common.event.FMLPreInitializationEvent;
+import net.minecraftforge.fml.common.registry.GameRegistry;
+
+public class TileEntityLoader {
+
+    public TileEntityLoader()
+    {
+    	if (ConfigLoader.useTileEntityToTickInvisibleLight)
+    		registerTileEntity(TileInvisibleLight.class, "invisible_light");
+    }
+
+    public void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String id)
+    {
+        GameRegistry.registerTileEntity(tileEntityClass, Baka943.MODID + ":" + id);
+    }
+    
+}

--- a/java/com/tartaric_acid/baka943/tileentity/TileEntityLoader.java
+++ b/java/com/tartaric_acid/baka943/tileentity/TileEntityLoader.java
@@ -11,8 +11,8 @@ public class TileEntityLoader {
 
     public TileEntityLoader()
     {
-    	if (ConfigLoader.useTileEntityToTickInvisibleLight)
-    		registerTileEntity(TileInvisibleLight.class, "invisible_light");
+        if (ConfigLoader.useTileEntityToTickInvisibleLight)
+            registerTileEntity(TileInvisibleLight.class, "invisible_light");
     }
 
     public void registerTileEntity(Class<? extends TileEntity> tileEntityClass, String id)

--- a/java/com/tartaric_acid/baka943/tileentity/TileInvisibleLight.java
+++ b/java/com/tartaric_acid/baka943/tileentity/TileInvisibleLight.java
@@ -8,13 +8,13 @@ import net.minecraft.util.ITickable;
 
 public class TileInvisibleLight extends TileEntity implements ITickable {
 
-	@Override
-	public void update() {
-		if (worldObj.isRemote) {
-			IBlockState state = worldObj.getBlockState(pos);
-			InvisibleLight invisibleLight = (InvisibleLight) state.getBlock();
-			invisibleLight.updateBlockState(state, worldObj, pos);
-		}
-	}
+    @Override
+    public void update() {
+        if (worldObj.isRemote) {
+            IBlockState state = worldObj.getBlockState(pos);
+            InvisibleLight invisibleLight = (InvisibleLight) state.getBlock();
+            invisibleLight.updateBlockState(state, worldObj, pos);
+        }
+    }
 
 }

--- a/java/com/tartaric_acid/baka943/tileentity/TileInvisibleLight.java
+++ b/java/com/tartaric_acid/baka943/tileentity/TileInvisibleLight.java
@@ -1,0 +1,20 @@
+package com.tartaric_acid.baka943.tileentity;
+
+import com.tartaric_acid.baka943.block.InvisibleLight;
+
+import net.minecraft.block.state.IBlockState;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.ITickable;
+
+public class TileInvisibleLight extends TileEntity implements ITickable {
+
+	@Override
+	public void update() {
+		if (worldObj.isRemote) {
+			IBlockState state = worldObj.getBlockState(pos);
+			InvisibleLight invisibleLight = (InvisibleLight) state.getBlock();
+			invisibleLight.updateBlockState(state, worldObj, pos);
+		}
+	}
+
+}

--- a/resources/assets/baka943/blockstates/invisible_light.json
+++ b/resources/assets/baka943/blockstates/invisible_light.json
@@ -5,6 +5,8 @@
   },
   "variants": {
     "normal": [{}],
-    "inventory": [{}]
+    "inventory": [{}],
+    "visible=false": [{}],
+	"visible=true": [{}]
   }
 }


### PR DESCRIPTION
1. 让被放置了的隐藏光源当且仅当玩家手上持有隐藏光源的时候才会被显示. (虽然用了TileEntity来帮助即时更新, 这样可能会降低游戏性能, 不过可以在配置文件中把它关掉而换成按Block的randomDisplayTick来更新的模式,这样负担应该会更小点,不过显示/隐藏隐藏光源的时候会有延迟)
2. 将所有代码中的tab替换成了4个空格, 以在GitHub上显示的更整齐